### PR TITLE
Remove OpenSea API dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ Thank you 🙏
 
 - Create an account at [Alchemy.com](https://alchemy.com) & create a new application on Ethereum mainnet. Once you've created a project, you should be able to grab the API key for it
 
-### - OpenSea (or another service with an NFT metadata API, e.g. Moralis, Venly)
-
-- Request an OpenSea API key [here](https://docs.opensea.io/reference/api-overview)
-
 ### - Twitter
 
 - Request a [Twitter Developer Account](https://developer.twitter.com/en/apply-for-access) (with [Elevated Access](https://developer.twitter.com/en/portal/products/elevated), then create a Twitter Developer App (make sure you change it to have both read/write permissions)
@@ -46,7 +42,6 @@ In the Settings section of your Heroku app you'll see a **Config Vars** section.
 - **ACCESS_TOKEN_SECRET** - The Access Token Secret of the Twitter Account your bot is posting from
 - **CONTRACT_ADDRESS** - The contract address you want to monitor sales for
 - **ALCHEMY_API_KEY** - Your unique Alchemy API key
-- **X_API_KEY** - Your unique OpenSea API key
 
 Now you're ready to release - just push up the code via. git to the Heroku remote (see [Heroku Remote](https://devcenter.heroku.com/articles/git#creating-a-heroku-remote) if unsure how).
 

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const { ethers } = require('ethers');
 // local
 const { markets } = require('./markets.js');
-const { getTokenData, getSeaportSalePrice } = require('./utils.js');
+const { getSeaportSalePrice } = require('./utils.js');
 const { currencies } = require('./currencies.js');
 const { transferEventTypes, saleEventTypes } = require('./log_event_types.js');
 const { tweet } = require('./tweet');
@@ -129,27 +129,23 @@ async function monitorContract() {
     //     return;
     // }
 
-    // retrieve metadata for the first (or only) ERC21 asset sold
-    const tokenData = await getTokenData(tokens[0]);
+    // retrieve metadata for the first (or only) ERC-721 asset sold
+    const metadata = await alchemy.nft.getNftMetadata(
+      process.env.CONTRACT_ADDRESS,
+      tokens[0],
+      {}
+    );
 
     // if more than one asset sold, link directly to etherscan tx, otherwise the marketplace item
     if (tokens.length > 1) {
       tweet(
-        `${_.get(
-          tokenData,
-          'assetName',
-          `#` + tokens[0]
-        )} & other assets bought for ${totalPrice} ${currency.name} on ${
+        `${metadata.title} & other assets bought for ${totalPrice} ${currency.name} on ${
           market.name
         } https://etherscan.io/tx/${transactionHash}`
       );
     } else {
       tweet(
-        `${_.get(
-          tokenData,
-          'assetName',
-          `#` + tokens[0]
-        )} bought for ${totalPrice} ${currency.name} on ${market.name} ${
+        `${metadata.title} bought for ${totalPrice} ${currency.name} on ${market.name} ${
           market.site
         }${process.env.CONTRACT_ADDRESS}/${tokens[0]}`
       );

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,4 @@
 // external
-const axios = require('axios');
-const retry = require('async-retry');
-const _ = require('lodash');
 const { ethers } = require('ethers');
 // local
 const { currencies } = require('./currencies.js');
@@ -35,43 +32,6 @@ function getSeaportSalePrice(decodedLogData) {
     const totalOfferAmount = offer.reduce(_reducer, 0);
 
     return totalOfferAmount;
-  }
-}
-
-async function getTokenData(tokenId) {
-  try {
-    const assetName = await retry(
-      async (bail) => {
-        // retrieve metadata for asset from opensea
-        const response = await axios.get(
-          `https://api.opensea.io/api/v1/asset/${process.env.CONTRACT_ADDRESS}/${tokenId}`,
-          {
-            headers: {
-              'X-API-KEY': process.env.X_API_KEY,
-            },
-          }
-        );
-
-        const data = response.data;
-
-        // just the asset name for now, but retrieve whatever you need
-        return {
-          assetName: _.get(data, 'name'),
-        };
-      },
-      {
-        retries: 5,
-      }
-    );
-
-    return assetName;
-  } catch (error) {
-    if (error.response) {
-      console.log(error.response.data);
-      console.log(error.response.status);
-    } else {
-      console.error(error.message);
-    }
   }
 }
 


### PR DESCRIPTION
Migrate to using Alchemy to retrieve token metadata, as

1) We use Alchemy already
2) We only require an OpenSea API key for this purpose

Resolves #16. 

